### PR TITLE
Add title and text to ingredientes scanner loading

### DIFF
--- a/lib/screens/history/widgets/history_content.dart
+++ b/lib/screens/history/widgets/history_content.dart
@@ -53,7 +53,7 @@ class _HistoryContentState extends State<HistoryContent> {
             return HistoryList(userScans: userScans);
           }
 
-          return LoadingWidget();
+          return const LoadingWidget();
         }
     );
   }

--- a/lib/screens/home/widgets/home_show.dart
+++ b/lib/screens/home/widgets/home_show.dart
@@ -54,7 +54,7 @@ class _HomeShowState extends State<HomeShow> {
           }
         }
 
-        return LoadingWidget();
+        return const LoadingWidget();
       },
     );
   }

--- a/lib/screens/products/widgets/product_content.dart
+++ b/lib/screens/products/widgets/product_content.dart
@@ -58,7 +58,7 @@ class _ProductContentState extends State<ProductContent> {
             return _buildContent(snapshot.data);
           }
 
-          return LoadingWidget();
+          return const LoadingWidget();
         }
     );
   }

--- a/lib/screens/scanner/scanner_page.dart
+++ b/lib/screens/scanner/scanner_page.dart
@@ -131,7 +131,7 @@ class _ScannerPageState extends State<ScannerPage> {
 
   Widget _buildBody(User user) {
     if (_loading) {
-      return LoadingWidget();
+      return const LoadingWidget();
     }
 
     switch (_step) {

--- a/lib/screens/scanner/widgets/scanner_ingredients_step.dart
+++ b/lib/screens/scanner/widgets/scanner_ingredients_step.dart
@@ -48,7 +48,10 @@ class ScannerIngredientsStep extends StatelessWidget {
             return _buildIngredients(snapshot);
           }
 
-          return LoadingWidget();
+          return const LoadingWidget(
+            title: 'Procesando imagen...',
+            text: 'El procesamiento puede tardar varios segundos. Por favor espere.'
+          );
         }
     );
   }

--- a/lib/screens/scanner/widgets/scanner_results_step.dart
+++ b/lib/screens/scanner/widgets/scanner_results_step.dart
@@ -50,7 +50,7 @@ class ScannerResultsStep extends StatelessWidget {
           return _buildProduct(snapshot);
         }
 
-        return LoadingWidget();
+        return const LoadingWidget();
       }
     );
   }

--- a/lib/widgets/design/loading_widget.dart
+++ b/lib/widgets/design/loading_widget.dart
@@ -1,19 +1,56 @@
 import 'package:flutter/material.dart';
+import 'package:yisty_app/widgets/design/subtitle.dart';
 
 import 'package:yisty_app/widgets/inherited_provider.dart';
 
 class LoadingWidget extends StatelessWidget {
+  const LoadingWidget({Key key, this.title, this.text}) : super(key: key);
+
+  final String title;
+  final String text;
+
+  Widget _buildProgressIndicator(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+
+    return CircularProgressIndicator(
+      valueColor: AlwaysStoppedAnimation<Color>(theme.primaryColor)
+    );
+  }
+
+  Widget _buildTitle() {
+    if (title == null) {
+      return Container();
+    }
+
+    return Subtitle(text: title);
+  }
+
+  Widget _buildText() {
+    if (text == null) {
+      return Container();
+    }
+
+    return Text(text, textAlign: TextAlign.center);
+  }
+
   @override
   Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
     final EdgeInsets padding = InheritedProvider.of(context).uiStore.screenPadding;
+    final Size mediaSize = MediaQuery.of(context).size;
 
     return Center(
       child: Container(
-        height: MediaQuery.of(context).size.height - padding.top - padding.bottom - kToolbarHeight,
+        width: mediaSize.width * 0.8,
+        height: mediaSize.height - padding.top - padding.bottom - kToolbarHeight,
         child: Center(
-          child: CircularProgressIndicator(
-            valueColor: AlwaysStoppedAnimation<Color>(theme.primaryColor)
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              _buildProgressIndicator(context),
+              _buildTitle(),
+              _buildText()
+            ],
           )
         )
       )

--- a/lib/widgets/products/product_information.dart
+++ b/lib/widgets/products/product_information.dart
@@ -52,7 +52,7 @@ class ProductInformation extends StatelessWidget {
   Widget _buildTitle(BuildContext context) {
     return Container(
       child: Column(
-        children: [
+        children: <Widget>[
           Subtitle(
             text: product.name,
             type: SubtitleType.h1,
@@ -90,7 +90,7 @@ class ProductInformation extends StatelessWidget {
 
     return Center(
       child: Column(
-        children: [
+        children: <Widget>[
           _buildImage(),
           _buildTitle(context),
           Container(
@@ -120,7 +120,7 @@ class ProductInformation extends StatelessWidget {
         Padding(
           padding: const EdgeInsets.all(15),
           child: Row(
-            children: [
+            children: <Widget>[
               const Padding(child: Icon(Icons.timelapse), padding: EdgeInsets.only(right: 5)),
               Text('Actualizado ${DateTimeUtils.ago(product.updatedAt).toLowerCase()}')
             ]


### PR DESCRIPTION
En las pruebas que hice con el endpoint de escaneo de ingredientes podia tardar 30s asi que agrego un texto en esa pantalla de loading para que no parezca que la app esta trabada.